### PR TITLE
Responsive fix

### DIFF
--- a/components/charts/charts.ts
+++ b/components/charts/charts.ts
@@ -261,6 +261,10 @@ export class BaseChart implements OnInit, OnDestroy {
 
   private refresh() {
 
+    if(this.options.responsive && this.parent.clientHeight === 0){
+      return setTimeout(()=>this.refresh(), 50);
+    }
+
     this.ngOnDestroy();
     let dataset:Array<any> = [];
 


### PR DESCRIPTION
I posted an issue earlier regarding mobile view (with Ionic 2 framework) .. 
The chart doesn't appear until you re-size the screen.

Also note that the CSS for the class `.charts` must be set to:

`.charts {
display: block;
}`