### PR TITLE
Remove Reference to 'View'

### DIFF
--- a/components/charts/charts.ts
+++ b/components/charts/charts.ts
@@ -1,5 +1,5 @@
 import {
-  Component, View, Directive,
+  Component, Directive,
   AfterViewChecked, OnDestroy, OnInit, OnChanges,
   EventEmitter, ElementRef, Input
 } from 'angular2/core';


### PR DESCRIPTION
It didn't appear to be used anywhere in charts.ts and was causing issues on newer beta versions of Angular 2.