### PR TITLE
Add display:block to host component

### DIFF
--- a/components/charts/charts.ts
+++ b/components/charts/charts.ts
@@ -9,7 +9,8 @@ declare var Chart:any;
 @Component({
   selector: 'base-chart',
   template: `<canvas style="width: 100%; height: 100%;"></canvas>`,
-  directives: [CORE_DIRECTIVES, FORM_DIRECTIVES, NgClass]
+  directives: [CORE_DIRECTIVES, FORM_DIRECTIVES, NgClass],
+  styles: [`:host { display: block; }`]
 })
 export class BaseChartComponent implements OnDestroy, OnChanges, OnInit {
   public static defaultColors:Array<number[]> = [


### PR DESCRIPTION
Angular2 components have a display type of inline-block by default.  This doesn't make sense for the chart and several issues mention users surprised they have to add display:block themselves.