### PR TITLE
Update chart labels

### DIFF
--- a/components/charts/charts.ts
+++ b/components/charts/charts.ts
@@ -67,6 +67,9 @@ export class BaseChartDirective implements OnDestroy, OnChanges, OnInit {
       // Check if the changes are in the data or datasets
       if (changes.hasOwnProperty('data') || changes.hasOwnProperty('datasets')) {
         this.chart.data.datasets = this.getDatasets();
+        if (changes.hasOwnProperty('labels')) {
+          this.chart.data.labels = this.labels;
+        }
         this.chart.update();
       } else {
         this.refresh();


### PR DESCRIPTION
The update method introduced in #410 and merged in #414 removed the ability of updating chart labels dynamically.

Closes #420 #445