### PR TITLE
Allow same color api for doughnut|pie|polar charts as with line|bar

### DIFF
--- a/components/charts/charts.ts
+++ b/components/charts/charts.ts
@@ -317,7 +317,7 @@ function getColors(chartType:string, index:number, count:number):Color {
 function copyInputColors(colors:any[]):Color {
   let copy:any = {};
   colors.forEach((element:any) => {
-    for (colorProp in element) {
+    for (let colorProp in element) {
       if (element.hasOwnProperty(colorProp)) {
         if (!copy.hasOwnProperty(colorProp)) {
           copy[colorProp] = [];

--- a/components/charts/charts.ts
+++ b/components/charts/charts.ts
@@ -141,7 +141,14 @@ export class BaseChartDirective implements OnDestroy, OnChanges, OnInit {
         .map((elm:number, index:number) => {
           let newElm:any = Object.assign({}, elm);
           if (this.colors && this.colors.length) {
-            Object.assign(newElm, this.colors[index]);
+            // Support similar color api for all chart types
+            if ((this.chartType === 'pie' ||
+                this.chartType === 'doughnut' ||
+                this.chartType === 'polarArea') && this.colors.length > 1 ) {
+              Object.assign(newElm, copyInputColors(this.colors));
+            } else {
+              Object.assign(newElm, this.colors[index]);
+            }
           } else {
             Object.assign(newElm, getColors(this.chartType, index, newElm.data.length));
           }
@@ -300,6 +307,26 @@ function getColors(chartType:string, index:number, count:number):Color {
     return formatBarColor(generateColor(index));
   }
   return generateColor(index);
+}
+
+/**
+ * Copy colors into correct object type for pie|doughnut|polar charts
+ * @param colors
+ * @returns {Color}
+ */
+function copyInputColors(colors:any[]):Color {
+  let copy:any = {};
+  colors.forEach((element:any) => {
+    for (colorProp in element) {
+      if (element.hasOwnProperty(colorProp)) {
+        if (!copy.hasOwnProperty(colorProp)) {
+          copy[colorProp] = [];
+        }
+        copy[colorProp].push(element[colorProp]);
+      }
+    }
+  });
+  return copy;
 }
 
 @NgModule({


### PR DESCRIPTION
### Current behavior
Unable to set different colors for each datapoint for doughnut, pie, or radar charts without using [this workaround](https://github.com/valor-software/ng2-charts/issues/251#issuecomment-225581645).

### New behavior
You should now be able to use the same method of setting colors for _all_ chart types. The `@Input() colors` object is inverted from an array of dataset color properties into an object where each color property is an array.

This might introduce breaking changes, but I tried to prevent that by making the inversion happen only when `this.colors` has a length `> 1`.

### Related
Should resolve issues #251 and #351 