### PR TITLE
Chart.js is now loaded as a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/valor-software/ng2-charts#readme",
   "dependencies": {
-    "chart.js": "^2.4.0"
+    "chart.js": "^2.5.0"
   },
   "peerDependencies": {
     "@angular/common": "^2.3.0",

--- a/src/charts/charts.ts
+++ b/src/charts/charts.ts
@@ -11,7 +11,7 @@ import {
   Directive
 } from '@angular/core';
 
-declare var Chart:any;
+import { Chart } from 'chart.js';
 
 /* tslint:disable-next-line */
 @Directive({selector: 'canvas[baseChart]', exportAs: 'base-chart'})
@@ -119,10 +119,6 @@ export class BaseChartDirective implements OnDestroy, OnChanges, OnInit {
       },
       options: options
     };
-
-    if (typeof Chart === 'undefined') {
-      throw new Error('ng2-charts configuration issue: Embedding Chart.js lib is mandatory');
-    }
 
     return new Chart(ctx, opts);
   }


### PR DESCRIPTION
- Updated `chart.js` to `v2.5.0`
- Loading `chart.js` as a module, meaning no need to load it with a `script` tag. and can compile into build file using `angular-cli`, `ionic-cli`, and other Angluar2 tools