### PR TITLE
Fixes related to #650

### DIFF
--- a/src/charts/charts.ts
+++ b/src/charts/charts.ts
@@ -65,11 +65,14 @@ export class BaseChartDirective implements OnDestroy, OnChanges, OnInit {
   public ngOnChanges(changes: SimpleChanges): void {
     if (this.initFlag) {
       // Check if the changes are in the data or datasets
-      if (changes.hasOwnProperty('data') || changes.hasOwnProperty('datasets')) {
+      if (changes.hasOwnProperty('data') || changes.hasOwnProperty('datasets') || changes.hasOwnProperty('labels')) {
         if (changes['data']) {
           this.updateChartData(changes['data'].currentValue);
-        } else {
+        } else if (changes['datasets']){
           this.updateChartData(changes['datasets'].currentValue);
+        }
+        if (changes['labels']){
+					this.chart.data.labels=changes['labels'].currentValue;
         }
 
         this.chart.update();


### PR DESCRIPTION
Cause for the behaviour as described in #650 was that, if the ngOnChanges hook is called with both data and label update values, the first condition catches the change in this update(change) cycle of the view and will only update the data(sets) and not the labels on the chart, as the recreation for all other data is skipped in the else condition.