### PR TITLE
Allow usage with Angular 4, like was done with ngx-bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "chart.js": "^2.5.0"
   },
   "peerDependencies": {
-    "@angular/common": "^2.3.0",
-    "@angular/core": "^2.3.0"
+    "@angular/common": "^2.3.0 || >=4.0.0",
+    "@angular/core": "^2.3.0 || >=4.0.0"
   },
   "devDependencies": {
     "@angular/common": "2.4.3",


### PR DESCRIPTION
Resolves https://github.com/valor-software/ng2-charts/issues/707
Resolves https://github.com/valor-software/ng2-charts/issues/745

Not sure whether there's any reason why this should be a bad idea; would be good to have some input from the owners.