### PR TITLE
fix (demo): fix links, navigation

### DIFF
--- a/demo/src/app/components/char-section.component.html
+++ b/demo/src/app/components/char-section.component.html
@@ -1,4 +1,4 @@
-<section id="${desc.id}" style="padding-top: 50px;">
+<section id="{{id}}" style="padding-top: 50px;">
   <div class="row">
     <div class="col-md-12">
       <h4>{{heading}}</h4>

--- a/demo/src/app/components/chart-section.component.ts
+++ b/demo/src/app/components/chart-section.component.ts
@@ -9,4 +9,5 @@ export class ChartSectionComponent {
   @Input() public ts:string;
   @Input() public html:string;
   @Input() public heading:string;
+  @Input() public id:string;
 }

--- a/demo/src/app/components/charts-section.ts
+++ b/demo/src/app/components/charts-section.ts
@@ -6,38 +6,78 @@ let doc = require('html-loader!markdown-loader!../../doc.md');
 @Component({
   selector: 'charts-section',
   template: `
-<br>
-<div class="row">
-  <h2>API</h2>
-  <div class="card card-block panel panel-default panel-body" [innerHTML]="doc"></div>
-</div>
+    <br>
+    <div class="row">
+      <h2>API</h2>
+      <div class="card card-block panel panel-default panel-body" [innerHTML]="doc"></div>
+    </div>
 
-<section [attr.id]="name">
-  <div class="row"><h1>{{name}}<small>(<a [attr.href]="src">src</a>)</small></h1></div>
+    <section [attr.id]="name">
+      <div class="row">
+        <h1>{{name}}
+          <small>(<a [attr.href]="src">src</a>)</small>
+        </h1>
+      </div>
 
-  <hr>
+      <hr>
 
-  <div class="row">
-    <h2>Example</h2>
-      
-    <chart-section [ts]="desc.lineChart.ts" [html]="desc.lineChart.html" [heading]="desc.lineChart.heading"><line-chart-demo></line-chart-demo></chart-section>
-    <chart-section [ts]="desc.barChart.ts" [html]="desc.barChart.html" [heading]="desc.barChart.heading"><bar-chart-demo></bar-chart-demo></chart-section>
-    <chart-section [ts]="desc.douChart.ts" [html]="desc.douChart.html" [heading]="desc.douChart.heading"><doughnut-chart-demo></doughnut-chart-demo></chart-section>
-    <chart-section [ts]="desc.radarChart.ts" [html]="desc.radarChart.html" [heading]="desc.radarChart.heading"><radar-chart-demo></radar-chart-demo></chart-section>
-    <chart-section [ts]="desc.pieChart.ts" [html]="desc.pieChart.html" [heading]="desc.pieChart.heading"><pie-chart-demo></pie-chart-demo></chart-section>
-    <chart-section [ts]="desc.polarChart.ts" [html]="desc.polarChart.html" [heading]="desc.polarChart.heading"><polar-area-chart-demo></polar-area-chart-demo></chart-section>
-    <chart-section [ts]="desc.baseChart.ts" [html]="desc.baseChart.html" [heading]="desc.baseChart.heading"><base-chart-demo></base-chart-demo></chart-section>
-  </div>
+      <div class="row">
+        <h2>Example</h2>
 
-  <br>
+        <chart-section [ts]="desc.lineChart.ts"
+                       [html]="desc.lineChart.html"
+                      
+                       [id]="desc.lineChart.id"
+                       [heading]="desc.lineChart.heading">
+          <line-chart-demo></line-chart-demo>
+        </chart-section>
+        <chart-section [ts]="desc.barChart.ts"
+                       [html]="desc.barChart.html"
+                       [id]="desc.barChart.id"
+                       [heading]="desc.barChart.heading">
+          <bar-chart-demo></bar-chart-demo>
+        </chart-section>
+        <chart-section [ts]="desc.douChart.ts"
+                       [html]="desc.douChart.html"
+                       [id]="desc.douChart.id"
+                       [heading]="desc.douChart.heading">
+          <doughnut-chart-demo></doughnut-chart-demo>
+        </chart-section>
+        <chart-section [ts]="desc.radarChart.ts"
+                       [html]="desc.radarChart.html"
+                       [id]="desc.radarChart.id"
+                       [heading]="desc.radarChart.heading">
+          <radar-chart-demo></radar-chart-demo>
+        </chart-section>
+        <chart-section [ts]="desc.pieChart.ts"
+                       [html]="desc.pieChart.html"
+                       [id]="desc.pieChart.id"
+                       [heading]="desc.pieChart.heading">
+          <pie-chart-demo></pie-chart-demo>
+        </chart-section>
+        <chart-section [ts]="desc.polarChart.ts"
+                       [html]="desc.polarChart.html"
+                       [id]="desc.polarChart.id"
+                       [heading]="desc.polarChart.heading">
+          <polar-area-chart-demo></polar-area-chart-demo>
+        </chart-section>
+        <chart-section [ts]="desc.baseChart.ts"
+                       [html]="desc.baseChart.html"
+                       [id]="desc.baseChart.id"
+                       [heading]="desc.baseChart.heading">
+          <base-chart-demo></base-chart-demo>
+        </chart-section>
+      </div>
 
-</section>
+      <br>
+
+    </section>
   `
 })
 
 export class ChartsSectionComponent {
   public name: string = 'Charts';
-  public src: string = 'https://github.com/valor-software/ng2-charts/blob/master/components/charts/charts.ts';
+  public src: string = 'https://github.com/valor-software/ng2-charts/blob/development/src/charts/charts.ts';
   public doc: string = doc;
   public desc: any = {
     lineChart: {

--- a/demo/src/doc.md
+++ b/demo/src/doc.md
@@ -9,13 +9,13 @@ imports: [
 ```
 
 ### Chart types
-There are one directive for all chart types: `base-chart`, and there are 6 types of charts: , `line`, `bar`, `radar`, `pie`, `polarArea`, `doughnut`.
+There are one directive for all chart types: `base-chart`, and there are 6 types of charts: `line`, `bar`, `radar`, `pie`, `polarArea`, `doughnut`.
 
 ### Properties
 
 **Note**: For more information about possible options please refer to original [chart.js](http://www.chartjs.org/docs) documentation
 
-- `data` (`Array<number[]> | number[]`) -  set of points of the chart, it should be `Array<number[]>` only for `line`, `bar` and `radar`, otherwise `number[]`;
+- `data` (`Array<number[]> | number[]`) -  set of points of the chart, it should be `Array<number[]>` only for `line`, `bar` and `radar`, otherwise `number[]`
 - `datasets` (`Array<{data: Array<number[]> | number[], label: string}>`) - `data` see about, the `label` for the dataset which appears in the legend and tooltips
 - `labels` (`?Array<any>`) - x axis labels. It's necessary for charts: `line`, `bar` and `radar`. And just labels (on hover) for charts: `polarArea`, `pie` and `doughnut`
 - `chartType` (`?string`) - indicates the type of charts, it can be: `line`, `bar`, `radar`, `pie`, `polarArea`, `doughnut`

--- a/demo/src/getting-started.md
+++ b/demo/src/getting-started.md
@@ -16,9 +16,9 @@
   ```html
   <script src="node_modules/chart.js/src/chart.js"></script>
   ```
-### Usage & Demo
+### Usage
  Demo and API details of ***ng2-charts*** can be found here:
-  [demo](http://valor-software.github.io/ng2-charts/) and [source code](https://github.com/valor-software/ng2-charts/tree/master/demo).
+  [source code](https://github.com/valor-software/ng2-charts/tree/master/demo).
 
 ### System.js
 


### PR DESCRIPTION
Fixed following issues.

1. Charts (src). Link throws Page not found error
2. Navigation using directives button in header doesn't work
3. Link demo leads to ng2-charts page itself (do we really need it?)
4. Chart types menu. Extra comma after colon
5. Properties. In list of properties only first line finishes with semicolon