### PR TITLE
Reset chart datasets if some are added or removed

### DIFF
--- a/src/charts/charts.ts
+++ b/src/charts/charts.ts
@@ -125,13 +125,17 @@ export class BaseChartDirective implements OnDestroy, OnChanges, OnInit {
 
   private updateChartData(newDataValues: number[] | any[]): void {
     if (Array.isArray(newDataValues[0].data)) {
-      this.chart.data.datasets.forEach((dataset: any, i: number) => {
-        dataset.data = newDataValues[i].data;
+      if (newDataValues.length === this.chart.data.datasets.length) {
+        this.chart.data.datasets.forEach((dataset: any, i: number) => {
+          dataset.data = newDataValues[i].data;
 
-        if (newDataValues[i].label) {
-          dataset.label = newDataValues[i].label;
-        }
-      });
+          if (newDataValues[i].label) {
+            dataset.label = newDataValues[i].label;
+          }
+        });
+      } else {
+        this.chart.data.datasets = [...newDataValues];
+      }
     } else {
       this.chart.data.datasets[0].data = newDataValues;
     }


### PR DESCRIPTION
Without this change, when removing datasets from an already initialized chart, it would crash when accessing the new (shorter) at positions matching the existing datasets.