### PR TITLE
Default colors are not exposed

### DIFF
--- a/projects/ng2-charts/src/public_api.ts
+++ b/projects/ng2-charts/src/public_api.ts
@@ -6,3 +6,4 @@ export * from './lib/charts.module';
 export * from './lib/base-chart.directive';
 export * from './lib/color';
 export * from './lib/colors';
+export * from './lib/default-colors';


### PR DESCRIPTION
Related to #840 and similar.  For styling purposes of other components, we might want to reuse default colors. They were previously accessible as 
`BaseChartDirective.defaultColors[ i ]`
The  current version (2.0.0-beta.14) is hiding them. Please expose the constant in public_api