### PR TITLE
fix: Change peer dependency to match Angular 9

### DIFF
--- a/projects/ng2-charts/package.json
+++ b/projects/ng2-charts/package.json
@@ -2,8 +2,8 @@
   "name": "ng2-charts",
   "version": "2.3.0",
   "peerDependencies": {
-    "@angular/common": "^7.2.0 || ^8.0.0",
-    "@angular/core": "^7.2.0 || ^8.0.0",
+    "@angular/common": "^7.2.0 || ^9.0.0",
+    "@angular/core": "^7.2.0 || ^9.0.0",
     "chart.js": "^2.7.3",
     "rxjs": "^6.3.3"
   },


### PR DESCRIPTION
Here we change the peer dependency to match Angular 9, but not Angular 10 since it's still in @next.