### PR TITLE
fix: match Angular 8 and Angular 9

### DIFF
--- a/projects/ng2-charts/package.json
+++ b/projects/ng2-charts/package.json
@@ -2,8 +2,8 @@
   "name": "ng2-charts",
   "version": "2.3.0",
   "peerDependencies": {
-    "@angular/common": "^7.2.0 || ^9.0.0",
-    "@angular/core": "^7.2.0 || ^9.0.0",
+    "@angular/common": "^7.2.0 || ^8.0.0 || ^9.0.0",
+    "@angular/core": "^7.2.0 || ^8.0.0 || ^9.0.0",
     "chart.js": "^2.7.3",
     "rxjs": "^6.3.3"
   },


### PR DESCRIPTION
In the dae5cc7 you dropped Angular 8 that looks like a mistake