### PR TITLE
Fix #1236 - Update peerDependencies to Angular 10

### DIFF
--- a/projects/ng2-charts/package.json
+++ b/projects/ng2-charts/package.json
@@ -2,8 +2,8 @@
   "name": "ng2-charts",
   "version": "2.3.2",
   "peerDependencies": {
-    "@angular/common": "^7.2.0 || ^8.0.0 || ^9.0.0",
-    "@angular/core": "^7.2.0 || ^8.0.0 || ^9.0.0",
+    "@angular/common": "^7.2.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+    "@angular/core": "^7.2.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "chart.js": "^2.7.3",
     "rxjs": "^6.3.3"
   },


### PR DESCRIPTION
The package works well will Angular 10, so we just need to add the corresponding versions as  possible values in the peerDependencies in package.json.