### PR TITLE
change lodash-es deepClone

### DIFF
--- a/projects/ng2-charts/src/lib/base-chart.directive.ts
+++ b/projects/ng2-charts/src/lib/base-chart.directive.ts
@@ -15,7 +15,7 @@ import { getColors } from './get-colors';
 import { Color } from './color';
 import { ThemeService } from './theme.service';
 import { Subscription } from 'rxjs';
-import { cloneDeep } from 'lodash-es';
+import cloneDeep from 'lodash-es/cloneDeep';
 import {
   Chart,
   ChartConfiguration,


### PR DESCRIPTION
change lodash-es deepClone method import to support treeshaking, the idea is to keep production bundle with just lodash functions that are used (not the whole library)