### PR TITLE
Avoid deep imports of lodash

### DIFF
--- a/projects/ng2-charts/ng-package.json
+++ b/projects/ng2-charts/ng-package.json
@@ -4,10 +4,7 @@
   "lib": {
     "entryFile": "src/public_api.ts",
     "umdModuleIds": {
-      "chart.js": "chart_js",
-      "lodash-es/pick": "_pick",
-      "lodash-es/merge": "_merge",
-      "lodash-es/assign": "_assign"
+      "chart.js": "chart_js"
     }
   },
   "allowedNonPeerDependencies": [

--- a/projects/ng2-charts/src/lib/base-chart.directive.ts
+++ b/projects/ng2-charts/src/lib/base-chart.directive.ts
@@ -15,8 +15,7 @@ import { ThemeService } from './theme.service';
 import { Subscription } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 
-import assign from 'lodash-es/assign';
-import merge from 'lodash-es/merge';
+import { assign, merge } from 'lodash-es';
 
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector

--- a/projects/ng2-charts/src/lib/charts.module.ts
+++ b/projects/ng2-charts/src/lib/charts.module.ts
@@ -25,7 +25,7 @@ import {
   Tooltip
 } from 'chart.js';
 import { builtInDefaults } from './get-colors';
-import merge from 'lodash-es/merge';
+import { merge } from 'lodash-es';
 import { ThemeService } from './theme.service';
 
 Chart.register(


### PR DESCRIPTION
This avoid warnings reported by Angular at compile time such as:

```
Warning: Entry point 'ng2-charts' contains deep imports into '/sites/theodia.lan/node_modules/lodash-es/assign'
```

Since this is already using the tree-shakable version of loadsh, there
is no reason to do any special tricks during import.