### PR TITLE
Fix rounding in bar chart example

### DIFF
--- a/src/app/bar-chart/bar-chart.component.ts
+++ b/src/app/bar-chart/bar-chart.component.ts
@@ -59,9 +59,9 @@ export class BarChartComponent {
       Math.round(Math.random() * 100),
       59,
       80,
-      Math.round((Math.random() * 100)),
+      Math.round(Math.random() * 100),
       56,
-      Math.round((Math.random() * 100)),
+      Math.round(Math.random() * 100),
       40 ];
 
     this.chart?.update();

--- a/src/app/bar-chart/bar-chart.component.ts
+++ b/src/app/bar-chart/bar-chart.component.ts
@@ -59,9 +59,9 @@ export class BarChartComponent {
       Math.round(Math.random() * 100),
       59,
       80,
-      (Math.random() * 100),
+      Math.round((Math.random() * 100)),
       56,
-      (Math.random() * 100),
+        Math.round((Math.random() * 100)),
       40 ];
 
     this.chart?.update();

--- a/src/app/bar-chart/bar-chart.component.ts
+++ b/src/app/bar-chart/bar-chart.component.ts
@@ -61,7 +61,7 @@ export class BarChartComponent {
       80,
       Math.round((Math.random() * 100)),
       56,
-        Math.round((Math.random() * 100)),
+      Math.round((Math.random() * 100)),
       40 ];
 
     this.chart?.update();


### PR DESCRIPTION
When looking at the [bar-chart example](https://valor-software.com/ng2-charts/#/BarChart) on the ng2-charts page, I discovered a rounding issue which was probably not intended. If it was, feel free to just delete this PR.

Screenshot:
<img width="1184" alt="Screenshot 2021-08-04 at 13 12 17" src="https://user-images.githubusercontent.com/44401560/128173061-8362a713-3791-48b0-8cab-5bf49b5f1d65.png">

