### PR TITLE
Better Major Angular Version Peer Dependencies.

### DIFF
--- a/projects/ng2-charts/package.json
+++ b/projects/ng2-charts/package.json
@@ -13,9 +13,9 @@
     "postbuild": "npm run copy:schemas && npm run copy:templates && npm run copy:collection"
   },
   "peerDependencies": {
-    "@angular/common": ">=14.0.0",
-    "@angular/core": ">=14.0.0",
-    "@angular/cdk": ">=14.0.0",
+    "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0",
+    "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0",
+    "@angular/cdk": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "chart.js": "^3.4.0 || ^4.0.0",
     "rxjs": "^6.5.3 || ^7.4.0"
   },


### PR DESCRIPTION
The current version requirements attempt to install `@angular/cdk@latest` (e.g. 16) in an Angular v15 project.