### PR TITLE
fix: fix Angular version compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ imports: [NgChartsModule];
 <table role="table">
  <tbody><tr>
   <td></td>
-  <td colspan="4">ng2-chart version</td>
+  <td colspan="5">ng2-chart version</td>
  </tr>
 
  <tr>
@@ -81,12 +81,14 @@ imports: [NgChartsModule];
   <td></td>
   <td></td>
   <td></td>
+  <td></td>
  </tr>
 
  <tr>
   <td>10</td>
   <td></td>
   <td>✓</td>
+  <td></td>
   <td></td>
   <td></td>
  </tr>
@@ -97,12 +99,14 @@ imports: [NgChartsModule];
   <td>✓</td>
   <td></td>
   <td></td>
+  <td></td>
  </tr>
 
  <tr>
   <td>12</td>
   <td></td>
   <td>✓</td>
+  <td></td>
   <td></td>
   <td></td>
  </tr>
@@ -113,6 +117,7 @@ imports: [NgChartsModule];
   <td></td>
   <td>✓</td>
   <td></td>
+  <td></td>
  </tr>
 
  <tr>
@@ -121,6 +126,7 @@ imports: [NgChartsModule];
   <td></td>
   <td>✓</td>
   <td>✓</td>
+  <td></td>
  </tr>
 
  <tr>
@@ -129,6 +135,7 @@ imports: [NgChartsModule];
   <td></td>
   <td>✓</td>
   <td>✓</td>
+  <td></td>
  </tr>
 
  <tr>

--- a/libs/ng2-charts/README.md
+++ b/libs/ng2-charts/README.md
@@ -63,7 +63,7 @@ imports: [NgChartsModule];
 <table role="table">
  <tbody><tr>
   <td></td>
-  <td colspan="4">ng2-chart version</td>
+  <td colspan="5">ng2-chart version</td>
  </tr>
 
  <tr>
@@ -81,12 +81,14 @@ imports: [NgChartsModule];
   <td></td>
   <td></td>
   <td></td>
+  <td></td>
  </tr>
 
  <tr>
   <td>10</td>
   <td></td>
   <td>✓</td>
+  <td></td>
   <td></td>
   <td></td>
  </tr>
@@ -97,12 +99,14 @@ imports: [NgChartsModule];
   <td>✓</td>
   <td></td>
   <td></td>
+  <td></td>
  </tr>
 
  <tr>
   <td>12</td>
   <td></td>
   <td>✓</td>
+  <td></td>
   <td></td>
   <td></td>
  </tr>
@@ -113,6 +117,7 @@ imports: [NgChartsModule];
   <td></td>
   <td>✓</td>
   <td></td>
+  <td></td>
  </tr>
 
  <tr>
@@ -121,6 +126,7 @@ imports: [NgChartsModule];
   <td></td>
   <td>✓</td>
   <td>✓</td>
+  <td></td>
  </tr>
 
  <tr>
@@ -129,6 +135,7 @@ imports: [NgChartsModule];
   <td></td>
   <td>✓</td>
   <td>✓</td>
+  <td></td>
  </tr>
 
  <tr>


### PR DESCRIPTION
This PR update the structure of the Angular version compatibility table.

![diff](https://github.com/valor-software/ng2-charts/assets/16042676/afed1da1-8243-44ba-9f21-40570f25684d)
