### PR TITLE
Make defaults type safe

### DIFF
--- a/libs/ng2-charts/src/lib/ng-charts.provider.ts
+++ b/libs/ng2-charts/src/lib/ng-charts.provider.ts
@@ -1,10 +1,11 @@
 import { InjectionToken } from '@angular/core';
 import {
   ChartComponentLike,
+  Defaults,
   registerables as defaultRegisterables,
 } from 'chart.js';
+import { DeepPartial } from 'chart.js/dist/types/utils';
 import { merge } from 'lodash-es';
-import { AnyObject } from 'chart.js/dist/types/basic';
 
 export const NG_CHARTS_CONFIGURATION =
   new InjectionToken<NgChartsConfiguration>('Configuration for ngCharts');
@@ -18,7 +19,7 @@ export type NgChartsConfiguration = {
   /**
    * Default configuration that can be used with `defaults.set()`.
    */
-  defaults?: AnyObject;
+  defaults?: DeepPartial<Defaults>;
 };
 
 /**


### PR DESCRIPTION
`AnyObject` is not a type safe solution. Instead of that use Chart.js util type `DeepPartial`. This way you can provide partial default objects.

With this change IDE can help you when you want to define defults:

![image](https://github.com/valor-software/ng2-charts/assets/11027521/8a7dce34-62e4-430a-97e8-1ab0818003ec)
