### PR TITLE
Fix(): Missing schematics folder in build:prod

### DIFF
--- a/libs/ng2-charts/project.json
+++ b/libs/ng2-charts/project.json
@@ -35,5 +35,6 @@
         "lintFilePatterns": ["{projectRoot}/**/*.ts", "{projectRoot}/**/*.html"]
       }
     }
-  }
+  },
+  "implicitDependencies": ["ng2-charts-schematics"]
 }


### PR DESCRIPTION
The script ```npm run build:prod``` removes the build of the lib ng2-charts-schematics, so i added it as a dependency of ng2-charts and that resulted in a correct build 